### PR TITLE
Add Admin Mode with teacher authentication

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login for admin actions
+- Teacher-only sign up and unregister actions
 
 ## Getting Started
 
@@ -30,7 +31,11 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login`                                                     | Login as teacher and get a bearer token                             |
+| POST   | `/auth/logout`                                                    | Logout current teacher session                                      |
+| GET    | `/auth/session`                                                   | Validate current bearer token session                               |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up a student for an activity (teacher only)                    |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity (teacher only)                |
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,14 @@
   </head>
   <body>
     <header>
+      <div id="user-menu" class="user-menu">
+        <button id="user-icon-btn" class="user-icon-btn" aria-label="User options">👤</button>
+        <div id="user-menu-panel" class="user-menu-panel hidden">
+          <p id="auth-status">Viewing as student</p>
+          <button id="login-btn" type="button">Login</button>
+          <button id="logout-btn" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +31,7 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="admin-notice" class="info">Teacher login required to register or unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -40,6 +49,24 @@
         <div id="message" class="hidden"></div>
       </section>
     </main>
+
+    <dialog id="login-dialog">
+      <form id="login-form" method="dialog">
+        <h3>Teacher Login</h3>
+        <div class="form-group">
+          <label for="username">Username:</label>
+          <input type="text" id="username" required />
+        </div>
+        <div class="form-group">
+          <label for="password">Password:</label>
+          <input type="password" id="password" required />
+        </div>
+        <div class="dialog-actions">
+          <button type="submit">Login</button>
+          <button id="cancel-login-btn" type="button">Cancel</button>
+        </div>
+      </form>
+    </dialog>
 
     <footer>
       <p>&copy; 2023 Mergington High School</p>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,57 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.user-menu {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.user-icon-btn {
+  background-color: white;
+  color: #1a237e;
+  border: none;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.user-icon-btn:hover {
+  background-color: #e8eaf6;
+}
+
+.user-menu-panel {
+  position: absolute;
+  right: 0;
+  margin-top: 8px;
+  width: 220px;
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  padding: 12px;
+  z-index: 10;
+}
+
+.user-menu-panel p {
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.user-menu-panel button {
+  width: 100%;
+  margin-top: 8px;
 }
 
 header h1 {
@@ -134,6 +179,12 @@ section h3 {
   margin-bottom: 15px;
 }
 
+.form-group input:disabled,
+.form-group select:disabled {
+  background-color: #f1f1f1;
+  cursor: not-allowed;
+}
+
 .form-group label {
   display: block;
   margin-bottom: 5px;
@@ -190,6 +241,27 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+dialog {
+  border: none;
+  border-radius: 6px;
+  padding: 20px;
+  width: 100%;
+  max-width: 420px;
+}
+
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.dialog-actions button {
+  flex: 1;
 }
 
 footer {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+{
+  "teachers": {
+    "teacher.alvarez": "mergington123",
+    "teacher.cho": "mergington123"
+  }
+}


### PR DESCRIPTION
## Summary
- add teacher login/logout/session endpoints backed by `src/teachers.json`
- restrict signup and unregister actions to authenticated teachers
- add header user icon, login modal, and admin-only registration controls in the UI
- update API documentation for new auth and protected endpoints

## Validation
- static diagnostics report no errors in updated backend/frontend files